### PR TITLE
Adds ability to create groups using space in Label, also finds new servers with empty label

### DIFF
--- a/cac_inv.py
+++ b/cac_inv.py
@@ -39,7 +39,6 @@ class CloudAtCostInventory(object):
         self.setupAPI()
 
         self.update_inventory()
-        print(self.groups)
         # Data to print
         if self.args.host:
             data_to_print = self.get_host_info(self.args.host)
@@ -47,7 +46,9 @@ class CloudAtCostInventory(object):
             # Display list of nodes for inventory
             data_to_print = {
                 _group: [server['label'] for server
-                         in self.inventory if server['label']],
+                         in self.inventory if server['label'] and server['group_label'] == _group],
+                group: [server['label'] for group
+                        in self.groups if server['label'] and server['group_label']== group],
                 '_meta': {
                     'hostvars': dict((server['label'],
                                       self.get_host_info(label=server['label']))
@@ -65,16 +66,17 @@ class CloudAtCostInventory(object):
         if res['status'] == 'ok':
             self.inventory = res['data']
             for server in self.inventory:
-                print('working on server')
                 if not server['label']:
                     server['label'] = server['servername']
-                    print('Server label changed')
-                if server['label'].find(' '):
-                    print("server Split Applied")
-                    split = server['label'].split()
+                if ' ' in server['label']:
+                    split = (server['label']).split()
                     server['label'] = split[1]
-                    if split[0] in self.groups:
+                    if split[0] not in self.groups:
                         self.groups.append(split[0])
+                    server['group_label'] = split[0]
+                else:
+                    server['group_label'] = _group
+
         else:
             print("Looks like CloudAtCost's API is down:")
             print("")

--- a/cac_inv.py
+++ b/cac_inv.py
@@ -42,32 +42,22 @@ class CloudAtCostInventory(object):
         # Data to print
         if self.args.host:
             data_to_print = self.get_host_info(self.args.host)
-        elif self.args.list and self.groups:
-            # Display list of servers and groups of servers
-            
-            data_to_print = {
-                _group: [server['label'] for server
-                         in self.inventory if server['label'] and server['group_label'] == _group],
-                group: [server['label'] for group
-                        in self.groups if server['label'] and server['group_label']== group],
-                '_meta': {
-                    'hostvars': dict((server['label'],
-                                      self.get_host_info(label=server['label']))
-                                     for server in self.inventory)
-                }
-            }
         elif self.args.list:
-             # Display list of servers if no groups are found.
-
-            data_to_print = {
-                _group: [server['label'] for server
-                         in self.inventory if server['label'] and server['group_label'] == _group],
+            # Generates output
+            groups = {}
+            for group in self.groups:
+                groups[group]= [server['label'] for server 
+                             in self.inventory if server['label'] and server['group_label'] == group]
+          
+            meta = {
                 '_meta': {
                     'hostvars': dict((server['label'],
                                       self.get_host_info(label=server['label']))
                                      for server in self.inventory)
                 }
             }
+            data_to_print = groups.copy()
+            data_to_print.update(meta)
 
         else:
             data_to_print = "Error: Invalid options"
@@ -84,7 +74,8 @@ class CloudAtCostInventory(object):
                 if not server['label']:
                     server['label'] = server['servername']
                     server['group_label'] = 'New'
-                    self.groups.append('New')
+                    if 'New' not in self.groups:
+                        self.groups.append('New')
                     server['isnew'] = True
                 else:
                     if ' ' in server['label']:
@@ -94,6 +85,8 @@ class CloudAtCostInventory(object):
                             self.groups.append(split[0])
                         server['group_label'] = split[0]
                     else:
+                        if _group not in self.groups:
+                            self.groups.append(_group)
                         server['group_label'] = _group
 
         else:

--- a/cac_inv.py
+++ b/cac_inv.py
@@ -120,6 +120,7 @@ class CloudAtCostInventory(object):
         retval['ansible_host'] = server["ip"]
         if server['isnew'] or 'New' in server['group_label']:
             retval['ansible_ssh_pass'] = server["rootpass"]
+            retval['ansible_pass'] = server["rootpass"]
         return retval
 
     def setupAPI(self):

--- a/cac_inv.py
+++ b/cac_inv.py
@@ -21,7 +21,7 @@ try:
 except ImportError:
     import simplejson as json
 
-_group = 'cloudatcost'  # a default group
+_group = 'csdfsfdasddatcost'  # a default group
 _prepend = 'cloud_'  # Prepend all CloudAtCost data, to avoid conflicts
 
 

--- a/cac_inv.py
+++ b/cac_inv.py
@@ -39,7 +39,7 @@ class CloudAtCostInventory(object):
         self.setupAPI()
 
         self.update_inventory()
-
+        print(self.groups)
         # Data to print
         if self.args.host:
             data_to_print = self.get_host_info(self.args.host)
@@ -64,9 +64,12 @@ class CloudAtCostInventory(object):
         res = self.api.get_server_info()
         if res['status'] == 'ok':
             for server in self.inventory:
+                print('working on server')
                 if not server['label']:
                     server['label'] = server['servername']
+                    print('Server label changed')
                 if server['label'].find(' '):
+                    print("server Split Applied")
                     split = server['label'].split()
                     server['label'] = split[1]
                     if split[0] in self.groups:

--- a/cac_inv.py
+++ b/cac_inv.py
@@ -92,7 +92,7 @@ class CloudAtCostInventory(object):
         # their labels aren't FQDNs
         retval['ansible_ssh_host'] = server["ip"]
         retval['ansible_host'] = server["ip"]
-
+	retval['ansible_ssh_pass'] = server["rootpass"]
         return retval
 
     def setupAPI(self):

--- a/cac_inv.py
+++ b/cac_inv.py
@@ -118,7 +118,7 @@ class CloudAtCostInventory(object):
         # their labels aren't FQDNs
         retval['ansible_ssh_host'] = server["ip"]
         retval['ansible_host'] = server["ip"]
-        if server['isnew']:
+        if server['isnew'] or 'New' in server['group_label']:
             retval['ansible_ssh_pass'] = server["rootpass"]
         return retval
 

--- a/cac_inv.py
+++ b/cac_inv.py
@@ -63,6 +63,7 @@ class CloudAtCostInventory(object):
         """Makes a CloudAtCost API call to get the list of servers."""
         res = self.api.get_server_info()
         if res['status'] == 'ok':
+            self.inventory = res['data']
             for server in self.inventory:
                 print('working on server')
                 if not server['label']:
@@ -74,8 +75,6 @@ class CloudAtCostInventory(object):
                     server['label'] = split[1]
                     if split[0] in self.groups:
                         self.groups.append(split[0])
-
-            self.inventory = res['data']
         else:
             print("Looks like CloudAtCost's API is down:")
             print("")

--- a/cac_inv.py
+++ b/cac_inv.py
@@ -68,6 +68,7 @@ class CloudAtCostInventory(object):
             for server in self.inventory:
                 if not server['label']:
                     server['label'] = server['servername']
+                    server['isnew'] = True
                 if ' ' in server['label']:
                     split = (server['label']).split()
                     server['label'] = split[1]
@@ -106,7 +107,8 @@ class CloudAtCostInventory(object):
         # their labels aren't FQDNs
         retval['ansible_ssh_host'] = server["ip"]
         retval['ansible_host'] = server["ip"]
-        retval['ansible_ssh_pass'] = server["rootpass"]
+        if server['isnew']:
+            retval['ansible_ssh_pass'] = server["rootpass"]
         return retval
 
     def setupAPI(self):

--- a/cac_inv.py
+++ b/cac_inv.py
@@ -42,8 +42,9 @@ class CloudAtCostInventory(object):
         # Data to print
         if self.args.host:
             data_to_print = self.get_host_info(self.args.host)
-        elif self.args.list:
-            # Display list of nodes for inventory
+        elif self.args.list and self.groups:
+            # Display list of servers and groups of servers
+            
             data_to_print = {
                 _group: [server['label'] for server
                          in self.inventory if server['label'] and server['group_label'] == _group],
@@ -55,6 +56,19 @@ class CloudAtCostInventory(object):
                                      for server in self.inventory)
                 }
             }
+        elif self.args.list:
+             # Display list of servers if no groups are found.
+
+            data_to_print = {
+                _group: [server['label'] for server
+                         in self.inventory if server['label'] and server['group_label'] == _group],
+                '_meta': {
+                    'hostvars': dict((server['label'],
+                                      self.get_host_info(label=server['label']))
+                                     for server in self.inventory)
+                }
+            }
+
         else:
             data_to_print = "Error: Invalid options"
 

--- a/cac_inv.py
+++ b/cac_inv.py
@@ -21,7 +21,7 @@ try:
 except ImportError:
     import simplejson as json
 
-_group = 'csdfsfdasddatcost'  # a default group
+_group = 'cloudatcost'  # a default group
 _prepend = 'cloud_'  # Prepend all CloudAtCost data, to avoid conflicts
 
 
@@ -33,6 +33,7 @@ class CloudAtCostInventory(object):
 
         self.args = self.parse_cli_args()
         self.inventory = {}
+        self.groups = []
 
         # CloudAtCost API Object
         self.setupAPI()
@@ -62,6 +63,15 @@ class CloudAtCostInventory(object):
         """Makes a CloudAtCost API call to get the list of servers."""
         res = self.api.get_server_info()
         if res['status'] == 'ok':
+            for server in self.inventory:
+                if not server['label']:
+                    server['label'] = server['servername']
+                if server['label'].find(' '):
+                    split = server['label'].split()
+                    server['label'] = split[1]
+                    if split[0] in self.groups:
+                        self.groups.append(split[0])
+
             self.inventory = res['data']
         else:
             print("Looks like CloudAtCost's API is down:")
@@ -92,7 +102,7 @@ class CloudAtCostInventory(object):
         # their labels aren't FQDNs
         retval['ansible_ssh_host'] = server["ip"]
         retval['ansible_host'] = server["ip"]
-	retval['ansible_ssh_pass'] = server["rootpass"]
+        retval['ansible_ssh_pass'] = server["rootpass"]
         return retval
 
     def setupAPI(self):

--- a/cac_inv.py
+++ b/cac_inv.py
@@ -66,17 +66,21 @@ class CloudAtCostInventory(object):
         if res['status'] == 'ok':
             self.inventory = res['data']
             for server in self.inventory:
+                server['isnew'] = False
                 if not server['label']:
                     server['label'] = server['servername']
+                    server['group_label'] = 'New'
+                    self.groups.append('New')
                     server['isnew'] = True
-                if ' ' in server['label']:
-                    split = (server['label']).split()
-                    server['label'] = split[1]
-                    if split[0] not in self.groups:
-                        self.groups.append(split[0])
-                    server['group_label'] = split[0]
                 else:
-                    server['group_label'] = _group
+                    if ' ' in server['label']:
+                        split = (server['label']).split()
+                        server['label'] = split[1]
+                        if split[0] not in self.groups:
+                            self.groups.append(split[0])
+                        server['group_label'] = split[0]
+                    else:
+                        server['group_label'] = _group
 
         else:
             print("Looks like CloudAtCost's API is down:")


### PR DESCRIPTION
Fixes #1 , #4 and #3 

I hope you like, it's not as pretty as your code but it does get the job done.

This fixes #4 by first checking for an empty label. If that condition is met then it will take the servername and stuff it into the label. The server name is typically c99999-cloudatcost-333333 or something similar.

This also parses the label for a " " in the name. If found it will split that string, adding the first part to the groups and the second part to the label.

So if you have in CAC these servers...
"Test Server1"
"Test Server2"
"Mysql Cluster01"
"Mysql Cluster02"
"Normalserver01"

Your output now becomes...
```
 "cloudatcost": [
    "Normalserver01"
  ],
"Test":[
  "Server1",
  "Server2"
],
"Mysql":[
   "Cluster01",
  "Cluster02"
]
```


Which I think will become very helpful in the future. Hope you like, forgive the commit history weirdness... I test on one server and write in an editor on my desktop and got a little mixed up.  And the code is kinda blah but I taught my self =).

I will need to some touch this up a bit, like convert the group_label to lowercase and maybe some other small things but I'm tired and need to rest. 

Thanks,
Levi